### PR TITLE
Set "as of" date as the current date

### DIFF
--- a/src/main/java/com/googlecode/phisix/api/parser/GsonAwareParser.java
+++ b/src/main/java/com/googlecode/phisix/api/parser/GsonAwareParser.java
@@ -82,6 +82,14 @@ public class GsonAwareParser implements Parser<Reader, Stocks> {
 				stocks.getStocks().add(stock);
 			}
 		}
+		if (stocks.getAsOf() == null) {
+			Calendar calendar = Calendar.getInstance(ASIA_MANILA);
+			calendar.set(Calendar.HOUR_OF_DAY, 0);
+			calendar.set(Calendar.MINUTE, 0);
+			calendar.set(Calendar.SECOND, 0);
+			calendar.set(Calendar.MILLISECOND, 0);
+			stocks.setAsOf(calendar);
+		}
 		
 		return stocks;
 	}

--- a/src/test/java/com/googlecode/phisix/api/parser/GsonAwareParserTest.java
+++ b/src/test/java/com/googlecode/phisix/api/parser/GsonAwareParserTest.java
@@ -20,6 +20,8 @@ import static org.junit.Assert.*;
 import java.io.BufferedReader;
 import java.io.FileReader;
 import java.io.Reader;
+import java.util.Calendar;
+import java.util.TimeZone;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -40,8 +42,12 @@ public class GsonAwareParserTest {
 		Reader reader = new BufferedReader(new FileReader("src/test/resources/JsonRawSample.txt"));
 		Stocks stocks = parser.parse(reader);
 		assertEquals(363, stocks.getStocks().size());
-//		Calendar expected = new GregorianCalendar(2012, 10, 23, 15, 46);
-//		expected.setTimeZone(TimeZone.getTimeZone("Asia/Manila"));
-//		assertEquals(expected, stocks.getAsOf());
+		Calendar expected = Calendar.getInstance();
+		expected.setTimeZone(TimeZone.getTimeZone("Asia/Manila"));
+		expected.set(Calendar.HOUR_OF_DAY, 0);
+		expected.set(Calendar.MINUTE, 0);
+		expected.set(Calendar.SECOND, 0);
+		expected.set(Calendar.MILLISECOND, 0);
+		assertEquals(expected, stocks.getAsOf());
 	}
 }


### PR DESCRIPTION
Context: the new PSE field does not contain a date field which is why this field was set to null. Setting this to the current date instead so it's not null.