### PR TITLE
Upgrade servlet version from 2.5 to 5.0 (Jakarta)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,9 +84,9 @@
 		</dependency>
 		<!-- provided dependencies -->
 		<dependency>	
-			<groupId>javax.servlet</groupId>
-			<artifactId>servlet-api</artifactId>
-			<version>2.5</version>
+			<groupId>jakarta.servlet</groupId>
+			<artifactId>jakarta.servlet-api</artifactId>
+			<version>5.0.0</version>
 			<scope>provided</scope>
 		</dependency>
 		<!-- These dependencies are here just for enabling logging -->

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<web-app version="2.5" xmlns="http://java.sun.com/xml/ns/javaee"
+<web-app version="5.0" xmlns="https://jakarta.ee/xml/ns/jakartaee"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd">
+	xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_5_0.xsd">
 	
 	<app-engine-apis>true</app-engine-apis>
 	


### PR DESCRIPTION
## Summary
Upgrades the servlet version from Servlet 2.5 (javax.servlet) to Jakarta Servlet 5.0.

## Changes
- Updated `pom.xml`: Changed `javax.servlet:servlet-api:2.5` to `jakarta.servlet:jakarta.servlet-api:5.0.0`
- Updated `web.xml`: Changed from Servlet 2.5 to Jakarta Servlet 5.0 schema
  - Updated namespace from `http://java.sun.com/xml/ns/javaee` to `https://jakarta.ee/xml/ns/jakartaee`
  - Updated version from `2.5` to `5.0`

## Testing
- All endpoints tested and verified working:
  - `/stocks.json` - Returns JSON with all stocks ✅
  - `/stocks` - Returns XML with all stocks ✅
  - `/stocks.xml` - Returns XML format ✅
  - `/stocks/BDO` - Symbol lookup ✅
  - `/stocks/SM.2024-01-15.json` - Historical data ✅
  - `/stocks/SM` - Current stock data ✅

## Compatibility
- Maintains compatibility with RestEasy 7.0 and Jakarta EE
- All existing tests pass (31 tests)
- No code changes required (no javax.servlet imports in codebase)